### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a creative coding / generative art sketch collection using [canvas-sketch](https://github.com/mattdesl/canvas-sketch). Each `.js` file at the repo root and in `sketches/` is a standalone browser-based visual sketch.
+
+### Running sketches
+
+Run any sketch with the `canvas-sketch` CLI dev server:
+
+```
+canvas-sketch <sketch-file.js> --port 9966 --no-open
+```
+
+This starts a local Browserify-based dev server with hot reloading. The server serves the sketch at `http://127.0.0.1:9966/`.
+
+- **2D canvas sketches** (e.g. `fire.js`, `joydivision.js`) use the `canvas-sketch` module pattern.
+- **3D WebGL sketches** (e.g. `three-template.js`, `stormshard.js`) use Three.js and require a WebGL-capable browser.
+- **Standalone sketches** (e.g. `circles.js`, `joydivision.js`) create their own canvas element directly (no `canvas-sketch` wrapper).
+
+### Dependencies
+
+- `canvas-sketch-cli` must be installed globally: `npm install -g canvas-sketch-cli`
+- Project dependencies: `npm install` (uses `package-lock.json`)
+
+### Known caveats
+
+- The `xdg-user-dir` warning on startup is harmless — it just means the sketch output (exported frames) defaults to the current working directory instead of `~/Downloads`.
+- `@tensorflow/tfjs-node` may fail to compile native bindings — this only affects the body-pix ML sketches and is not required for most sketches.
+- There is no linter, test suite, or build command configured in `package.json`. The project is a collection of standalone creative coding experiments.
+- Both `package-lock.json` and `yarn.lock` exist; prefer `npm install` to match the lockfile used by the update script.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this creative coding sketch collection.

### What's included

- How to run individual sketches with `canvas-sketch-cli`
- Dependency installation notes
- Known caveats (xdg-user-dir warning, tfjs-node native bindings, no lint/test/build scripts)

### Environment verification

Both 2D canvas and 3D WebGL sketches were tested and confirmed working:

**Fire sketch (2D canvas with Perlin noise animation)**
[fire_sketch_animation_demo.mp4](https://cursor.com/agents/bc-e5acaae6-4cd0-40a4-8627-1ccf7bb52e81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffire_sketch_animation_demo.mp4)

**Three.js template (3D WebGL with OrbitControls interaction)**
[threejs_cube_interactive_demo.mp4](https://cursor.com/agents/bc-e5acaae6-4cd0-40a4-8627-1ccf7bb52e81/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fthreejs_cube_interactive_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5acaae6-4cd0-40a4-8627-1ccf7bb52e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5acaae6-4cd0-40a4-8627-1ccf7bb52e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

